### PR TITLE
0.6.0: Python generics, LaTeX, C#

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add C# support for dark theme
 - Fix Python 3.12 generics syntax (PEP 695)
+- Add LaTeX Syntax colors
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add C/C++ syntax colors
 - Add Java syntax colors
+- Add Kotlin syntax colors
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.6.0
+
+- Add C# support for dark theme
+- Fix Python 3.12 generics syntax (PEP 695)
+
 ## 0.5.0
 
 - Add C/C++ syntax colors

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "JetBrains New UI Color Theme Extended",
   "description": "JetBrains IDEs New UI inspired color theme. Minimize distractions and boost productivity",
   "publisher": "fogio",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "homepage": "https://github.com/fogio-org/vscode-jetbrains-color-theme",
   "bugs": {

--- a/themes/dark-jetbrains-color-theme.json
+++ b/themes/dark-jetbrains-color-theme.json
@@ -2999,7 +2999,48 @@
 				"foreground": "#c48d69",
 				"fontStyle": ""
 			}
-		}
+		},
+		// {
+		// 	"scope": [
+		// 		"text.tex.latex comment.line.percentage",
+		// 	],
+		// 	"settings": {
+		// 		"foreground": "#5F826B"
+		// 	}
+		// },
+		{
+			"scope": [
+				"text.tex.latex comment",
+			],
+			"settings": {
+				"foreground": "#7A7E85"
+			}
+		},
+		{
+			"scope": [
+				"text.tex.latex keyword",
+				"text.tex.latex support.function",
+			],
+			"settings": {
+				"foreground": "#CF8E6D"
+			}
+		},
+		{
+			"scope": [
+				"text.tex.latex support.class.math.block",
+			],
+			"settings": {
+				"foreground": "#6AAB73"
+			}
+		},
+		{
+			"scope": [
+				"text.tex.latex support.class.math.block constant",
+			],
+			"settings": {
+				"foreground": "#CF8E6D"
+			}
+		},
     ],
 	"semanticTokenColors": {
 		"function": "#57AAF7",

--- a/themes/dark-jetbrains-color-theme.json
+++ b/themes/dark-jetbrains-color-theme.json
@@ -370,6 +370,7 @@
 				"source.python constant.character.format.placeholder.other",
 				"source.python meta.function storage.type.function ",
 				"source.python meta.class storage.type.class",
+				"source.python storage.type.class",
 				"source.python keyword.control.flow",
 				"source.python keyword.control.import",
 				"source.python storage.type.format",
@@ -2999,5 +3000,11 @@
 				"fontStyle": ""
 			}
 		}
-    ]
+    ],
+	"semanticTokenColors": {
+		"function": "#57AAF7",
+		"property": "#C77DBB",
+		"enumMember": "#C77DBB",
+		"typeParameter": "#16baac",
+	}
 }

--- a/themes/dark-jetbrains-color-theme.json
+++ b/themes/dark-jetbrains-color-theme.json
@@ -2900,5 +2900,66 @@
 				"foreground": "#C77DBB",
 			}
 		},
+		{
+			"scope": [
+				"source.kotlin keyword",
+				"source.kotlin storage.modifier",
+				"source.kotlin support.class",
+				"source.kotlin storage.type",
+			],
+			"settings": {
+				"foreground": "#CF8E6D",
+			}
+		},
+		{
+			"scope": [
+				"source.kotlin comment.block",
+			],
+			"settings": {
+				"foreground": "#5F826B",
+			}
+		},
+		{
+			"scope": [
+				"source.kotlin storage.type.annotation",
+			],
+			"settings": {
+				"foreground": "#B3AE60",
+			}
+		},
+		{
+			"scope": [
+				"source.kotlin keyword.operator",
+				"source.kotlin entity.string.template.element",
+			],
+			"settings": {
+				"foreground": "#BCBEC4",
+			}
+		},
+		{
+			"scope": [
+				"source.kotlin entity.name.function",
+			],
+			"settings": {
+				"foreground": "#56A8F5",
+			}
+		},
+		{
+			"scope": [
+				"source.kotlin support.function",
+			],
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": [
+				"source.kotlin punctuation.definition.keyword",
+				"source.kotlin punctuation.section.block",
+			],
+			"settings": {
+				"foreground": "#CF8E6D",
+			}
+		},
     ]
 }


### PR DESCRIPTION
- Add C# support for dark theme (#17)
- Fix Python 3.12 generics syntax (PEP 695) (#19)
- Add LaTeX Syntax colors (#16)