### PR TITLE
Add Dart/Flutter syntax highlighting support

### DIFF
--- a/themes/dark-jetbrains-color-theme.json
+++ b/themes/dark-jetbrains-color-theme.json
@@ -2546,11 +2546,18 @@
 		},
 		{
 			"scope": [
-				"source.dart string variable",
+				"source.dart string variable"
+			],
+			"settings": {
+				"foreground": "#BCBEC4"
+			}
+		},
+		{
+			"scope": [
 				"source.dart punctuation.definition.template-expression"
 			],
 			"settings": {
-				"foreground": "#CF8E6D"
+				"foreground": "#BCBEC4" 
 			}
 		},
 		{

--- a/themes/dark-jetbrains-color-theme.json
+++ b/themes/dark-jetbrains-color-theme.json
@@ -2430,8 +2430,12 @@
 		{
 			"scope": [
 				"source.dart keyword",
+				"source.dart keyword.declaration",
+				"source.dart keyword.control",
 				"source.dart storage.type.primitive",
-				"source.dart storage.modifier"
+				"source.dart storage.modifier",
+				"source.dart constant.language",
+				"source.dart variable.language"
 			],
 			"settings": {
 				"foreground": "#CF8E6D"
@@ -2439,7 +2443,7 @@
 		},
 		{
 			"scope": [
-				"source.dart string",
+				"source.dart string"
 			],
 			"settings": {
 				"foreground": "#6AAB73"
@@ -2447,11 +2451,31 @@
 		},
 		{
 			"scope": [
+				"source.dart constant.character.escape"
+			],
+			"settings": {
+				"foreground": "#CF8E6D"
+			}
+		},
+		{
+			"scope": [
+				"source.dart constant.numeric"
+			],
+			"settings": {
+				"foreground": "#2AACB8"
+			}
+		},
+		{
+			"scope": [
 				"source.dart keyword.operator.assignment",
 				"source.dart keyword.operator.arithmetic",
-				"source.dart comment.block.documentation variable.name",
 				"source.dart keyword.operator.ternary",
+				"source.dart keyword.operator.logical",
+				"source.dart keyword.operator.comparison",
+				"source.dart keyword.operator.bitwise",
 				"source.dart keyword.operator",
+				"source.dart punctuation.terminator",
+				"source.dart punctuation.separator"
 			],
 			"settings": {
 				"foreground": "#BCBEC4"
@@ -2459,7 +2483,7 @@
 		},
 		{
 			"scope": [
-				"source.dart entity.name.function",
+				"source.dart entity.name.function"
 			],
 			"settings": {
 				"foreground": "#56A8F5"
@@ -2467,7 +2491,18 @@
 		},
 		{
 			"scope": [
+				"source.dart entity.name.type.class",
+				"source.dart entity.other.inherited-class",
+				"source.dart support.class"
+			],
+			"settings": {
+				"foreground": "#16BAAC"
+			}
+		},
+		{
+			"scope": [
 				"source.dart storage.type.annotation",
+				"source.dart punctuation.definition.annotation"
 			],
 			"settings": {
 				"foreground": "#B3AE60"
@@ -2475,10 +2510,47 @@
 		},
 		{
 			"scope": [
-				"source.dart support.class",
+				"source.dart variable.other.property"
 			],
 			"settings": {
 				"foreground": "#C77DBB"
+			}
+		},
+		{
+			"scope": [
+				"source.dart comment.block.documentation"
+			],
+			"settings": {
+				"foreground": "#5F826B",
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": [
+				"source.dart comment.block.documentation keyword",
+				"source.dart comment.block.documentation storage.type"
+			],
+			"settings": {
+				"foreground": "#67A37C"
+			}
+		},
+		{
+			"scope": [
+				"source.dart comment.block.documentation variable.name",
+				"source.dart comment.block.documentation variable.parameter"
+			],
+			"settings": {
+				"foreground": "#ABADB3",
+				"fontStyle": ""
+			}
+		},
+		{
+			"scope": [
+				"source.dart string variable",
+				"source.dart punctuation.definition.template-expression"
+			],
+			"settings": {
+				"foreground": "#CF8E6D"
 			}
 		},
 		{
@@ -3047,5 +3119,14 @@
 		"property": "#C77DBB",
 		"enumMember": "#C77DBB",
 		"typeParameter": "#16baac",
+		"class:dart": "#56A8F5",
+		"class.defaultLibrary:dart": "#BCBEC4", 
+		"enum:dart": "#BCBEC4",
+		"type:dart": "#BCBEC4",
+		"interface:dart": "#BCBEC4",
+		"annotation:dart": "#B3AE60",
+		"variable:dart": "#C77DBB",
+		"parameter:dart": "#BCBEC4",
+		"keyword:dart": "#CF8E6D"
 	}
 }

--- a/themes/light-jetbrains-color-theme.json
+++ b/themes/light-jetbrains-color-theme.json
@@ -469,5 +469,144 @@
 				"fontStyle": ""
 			},
 		},
-    ]
+
+		{
+			"scope": [
+				"source.dart keyword",
+				"source.dart keyword.declaration",
+				"source.dart keyword.control",
+				"source.dart storage.type.primitive",
+				"source.dart storage.modifier",
+				"source.dart constant.language",
+				"source.dart variable.language"
+			],
+			"settings": {
+				"foreground": "#0033B3"
+			}
+		},
+		{
+			"scope": [
+				"source.dart string"
+			],
+			"settings": {
+				"foreground": "#067D17"
+			}
+		},
+		{
+			"scope": [
+				"source.dart constant.character.escape"
+			],
+			"settings": {
+				"foreground": "#0037A6"
+			}
+		},
+		{
+			"scope": [
+				"source.dart constant.numeric"
+			],
+			"settings": {
+				"foreground": "#1750EB"
+			}
+		},
+		{
+			"scope": [
+				"source.dart keyword.operator.assignment",
+				"source.dart keyword.operator.arithmetic",
+				"source.dart keyword.operator.ternary",
+				"source.dart keyword.operator.logical",
+				"source.dart keyword.operator.comparison",
+				"source.dart keyword.operator.bitwise",
+				"source.dart keyword.operator",
+				"source.dart punctuation.terminator",
+				"source.dart punctuation.separator"
+			],
+			"settings": {
+				"foreground": "#080808"
+			}
+		},
+		{
+			"scope": [
+				"source.dart entity.name.function"
+			],
+			"settings": {
+				"foreground": "#00627A"
+			}
+		},
+		{
+			"scope": [
+				"source.dart entity.name.type.class",
+				"source.dart entity.other.inherited-class",
+				"source.dart support.class"
+			],
+			"settings": {
+				"foreground": "#00627A"
+			}
+		},
+		{
+			"scope": [
+				"source.dart storage.type.annotation",
+				"source.dart punctuation.definition.annotation"
+			],
+			"settings": {
+				"foreground": "#9E880D"
+			}
+		},
+		{
+			"scope": [
+				"source.dart variable.other.property"
+			],
+			"settings": {
+				"foreground": "#871094"
+			}
+		},
+		{
+			"scope": [
+				"source.dart comment.block.documentation"
+			],
+			"settings": {
+				"foreground": "#8C8C8C",
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": [
+				"source.dart comment.block.documentation keyword",
+				"source.dart comment.block.documentation storage.type"
+			],
+			"settings": {
+				"foreground": "#8C8C8C",
+				"fontStyle": "bold italic"
+			}
+		},
+		{
+			"scope": [
+				"source.dart comment.block.documentation variable.name",
+				"source.dart comment.block.documentation variable.parameter"
+			],
+			"settings": {
+				"foreground": "#4a4a4a",
+				"fontStyle": ""
+			}
+		},
+		{
+			"scope": [
+				"source.dart string variable",
+				"source.dart punctuation.definition.template-expression"
+			],
+			"settings": {
+				"foreground": "#0033B3"
+			}
+		},
+    ],
+	"semanticTokenColors": {
+		"class:dart": "#00627A",
+		"class.defaultLibrary:dart": "#080808",
+		"enum:dart": "#00627A",
+		"type:dart": "#00627A",
+		"interface:dart": "#00627A",
+		"annotation:dart": "#9E880D",
+		"variable:dart": "#871094",
+		"parameter:dart": "#080808",
+		"keyword:dart": "#0033B3"
+	}
 }

--- a/themes/light-jetbrains-color-theme.json
+++ b/themes/light-jetbrains-color-theme.json
@@ -590,11 +590,18 @@
 		},
 		{
 			"scope": [
-				"source.dart string variable",
+				"source.dart string variable"
+			],
+			"settings": {
+				"foreground": "#080808"
+			}
+		},
+		{
+			"scope": [
 				"source.dart punctuation.definition.template-expression"
 			],
 			"settings": {
-				"foreground": "#0033B3"
+				"foreground": "#080808"
 			}
 		},
     ],


### PR DESCRIPTION
- Expand Dart token color rules in the dark theme from 6 basic rules to 13 comprehensive rules covering keywords, strings, escape sequences, numbers, operators, class types, annotations, properties, doc comments, and string interpolation
- Add full Dart token color support to the light theme (previously had none)
- Add Dart-specific semantic token colors to both themes (class, enum, type, interface, annotation, variable, parameter, keyword) for accurate highlighting of Flutter widget classes, SDK types, and other Dart-specific constructs